### PR TITLE
Fixed crash when only subsribed to one channel.

### DIFF
--- a/QPubNub.cpp
+++ b/QPubNub.cpp
@@ -225,12 +225,16 @@ void QPubNub::onSubscribeReadyRead() {
   m_timeToken = timeTokenElement.toString();
   QJsonValue channelListString = response.at(2);
   QStringList channels;
+  QJsonArray messages = firstElement.toArray();
   if (channelListString.isString()) {
     channels = channelListString.toString().split(',');
   } else {
-    channels << m_channelUrlPart;
+    int len = messages.isEmpty() ? 0 : messages.size();
+    for (int i = 0; i < len; i++)
+    {
+        channels << m_channelUrlPart;
+    }
   }
-  QJsonArray messages = firstElement.toArray();
   if (messages.isEmpty()) {
     emit connected();
   } else {


### PR DESCRIPTION
Pubnub doesn't give you the channel list when subscribed to only one
channel, so we're creating the list ourselves. Otherwise, when you
receive more than 1 message per reply, it would crash.
