### PR TITLE
Fixed receiving duplicate messages.

### DIFF
--- a/QPubNub.h
+++ b/QPubNub.h
@@ -176,4 +176,5 @@ private:
   QSet<QString> m_channels;
   QString m_channelUrlPart;
   int m_trace;
+  bool m_subsribeInvoked;
 };


### PR DESCRIPTION
Because the subscribe() method was queued on each run of
subscribe(QString), you would receive the messages duplicated to as
many channels you subscribed to.
