### PR TITLE
Fixed duplicate messages on multiple subscribes.

### DIFF
--- a/QPubNub.h
+++ b/QPubNub.h
@@ -176,4 +176,5 @@ private:
   QSet<QString> m_channels;
   QString m_channelUrlPart;
   int m_trace;
+  QNetworkReply * m_currentSubscribeReply;
 };


### PR DESCRIPTION
Subscribing to different channels at different times meant multiple
requests with the same time token were pending, causing duplicate
messages.
