### PR TITLE
Modify header to use the Qt signal and slot macros

### DIFF
--- a/QPubNub.h
+++ b/QPubNub.h
@@ -108,7 +108,7 @@ class QPubNub : public QObject {
   Q_PROPERTY(bool resumeOnReconnect MEMBER m_resumeOnReconnect)
   Q_PROPERTY(QString origin MEMBER m_origin RESET resetOrigin)
   Q_PROPERTY(bool ssl MEMBER m_ssl)
-signals:
+Q_SIGNALS:
   void connected();
   void error(QString message, const int code) const;
   void message(QJsonValue value, QString timeToke, QString channel);
@@ -150,7 +150,7 @@ protected:
   void connectNotify(const QMetaMethod& signal);
   void disconnectNotify(const QMetaMethod& signal);
 
-private slots:
+private Q_SLOTS:
   void onTimeFinished();
   void publishFinished();
   void onSubscribeReadyRead();


### PR DESCRIPTION
Modify header to use the Qt signal and slot macros to improve integration compatibility with other code bases which use 3rd party signal/slot libraries
